### PR TITLE
Fix some typos in English locale

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,10 +4,10 @@ index:
   subtitle: just a click away in your Apple Wallet
   onboarding:
     paragraphs:
-    - No matter if you go to movies, a concert or a reaturant – nowadays you have to show 
+    - No matter if you go to movies, a concert or a restaurant – nowadays you have to show 
       the European COVID Green Pass at more and more places to prove that you are vaccinated, 
       tested or recovered. With our website there is no need for an additional app, just 
-      scan your code once and add it to your Apple wallet. And next time you’re in line to 
+      scan your code once and add it to your Apple Wallet. And next time you’re in line to 
       show your QR code, you don’t have to search for it anymore – it’s right there, with a 
       double tap on your lock button.
     icons:


### PR DESCRIPTION
In the main view of the app, the word "restaurant" is misspelt as "reaturant". Furthermore, whereas the "Apple Wallet" nomenclature is used in most places of the locale, the front page defiantly and incorrectly uses the "Apple wallet" (lowercase W) nomenclature. This pull request fixes these typos.